### PR TITLE
Update pytorch_builder.py

### DIFF
--- a/hiddenlayer/pytorch_builder.py
+++ b/hiddenlayer/pytorch_builder.py
@@ -69,7 +69,7 @@ def import_graph(hl_graph, model, args, input_names=None, verbose=False):
     # Run the Pytorch graph to get a trace and generate a graph from it
     trace, out = torch.jit._get_trace_graph(model, args)
     try:
-        torch_graph = torch.onnx._optimize_trace(trace, torch.onnx.OperatorExportTypes.ONNX)
+        torch_graph = torch.onnx._optimize_graph(trace, torch.onnx.OperatorExportTypes.ONNX)
     except TypeError as e:
         torch_graph = trace    
 


### PR DESCRIPTION
Installation fails if using _optimize_trace when using pytorch version 2.0.0+cu117. Replacing by _get_trace_graph fixes this issue.